### PR TITLE
Remove redundant 100% classes. Work by @nenadjelovac [refs #2]

### DIFF
--- a/_tools.widths.scss
+++ b/_tools.widths.scss
@@ -28,6 +28,8 @@ $inuit-use-fractions: true !default;
     // Loop through the number of columns for each denominator of our fractions.
     @each $inuit-widths-denominator in $inuit-widths-columns {
 
+        // If we’re trying to make wholes, just spit a 100% width utility out
+        // one time only.
         @if ($inuit-widths-denominator == 1) {
             .#{$inuit-widths-namespace}u-1#{$inuit-widths-delimiter}1#{$inuit-widths-breakpoint} {
                 width: 100% !important;

--- a/_tools.widths.scss
+++ b/_tools.widths.scss
@@ -28,13 +28,21 @@ $inuit-use-fractions: true !default;
     // Loop through the number of columns for each denominator of our fractions.
     @each $inuit-widths-denominator in $inuit-widths-columns {
 
-        // Begin creating a numberator for our fraction up until we hit the
-        // denominator.
-        @for $inuit-widths-numerator from 1 through $inuit-widths-denominator {
+        @if ($inuit-widths-denominator == 1) {
+            .#{$inuit-widths-namespace}u-1#{$inuit-widths-delimiter}1#{$inuit-widths-breakpoint} {
+                width: 100% !important;
+            }
+        } @else {
 
-            // Build a class in the format `.u-3/4` or `.u-3-of-4`.
-            .#{$inuit-widths-namespace}u-#{$inuit-widths-numerator}#{$inuit-widths-delimiter}#{$inuit-widths-denominator}#{$inuit-widths-breakpoint} {
-                width: ($inuit-widths-numerator / $inuit-widths-denominator) * 100% !important;
+            // Begin creating a numberator for our fraction up until we hit the
+            // denominator.
+            @for $inuit-widths-numerator from 1 to $inuit-widths-denominator {
+
+                // Build a class in the format `.u-3/4` or `.u-3-of-4`.
+                .#{$inuit-widths-namespace}u-#{$inuit-widths-numerator}#{$inuit-widths-delimiter}#{$inuit-widths-denominator}#{$inuit-widths-breakpoint} {
+                    width: ($inuit-widths-numerator / $inuit-widths-denominator) * 100% !important;
+                }
+
             }
 
         }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "inuit-tools-widths",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/inuitcss/tools.widths",
   "authors": [
     "Harry Roberts <harry@csswizardry.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "inuit-tools-widths",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/inuitcss/tools.widths",
   "authors": [
     "Harry Roberts <harry@csswizardry.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inuit-tools-widths",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "inuitcss’ widths generator",
   "main": "_tools.widths.scss",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inuit-tools-widths",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "inuitcss’ widths generator",
   "main": "_tools.widths.scss",
   "repository": {


### PR DESCRIPTION
Remove redundant/unnecessary `width: 100%` utilities in place of a hard-coded one-off.
