### PR TITLE
Allow to change $inuit-widths-delimiter value if $inuit-use-fractions is false.

### DIFF
--- a/_tools.widths.scss
+++ b/_tools.widths.scss
@@ -15,12 +15,14 @@ $inuit-widths-namespace: $inuit-namespace !default;
 // `<div class="u-1-of-4">`?
 $inuit-use-fractions: true !default;
 
+$inuit-widths-delimiter-alternative: -of- !default;
+
 // Depending on what we chose for `$inuit-use-fractions`, create the relevant
 // delimiter.
 @if ($inuit-use-fractions == true) {
     $inuit-widths-delimiter: \/ !global;
 } @else {
-    $inuit-widths-delimiter: -of- !global;
+    $inuit-widths-delimiter: $inuit-widths-delimiter-alternative;
 }
 
 @mixin inuit-widths($inuit-widths-columns, $inuit-widths-breakpoint: null) {


### PR DESCRIPTION
Is great to use an alternative for classes like  "u-1/4". Haml doesn't allow easilly to use characters like '/' in class names. But I want to use "u-1of4" instead of "u-1-of-4" so I suggest to create a alternative variable.
